### PR TITLE
Added rhino version toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ parameters, a GH component for each script in the CEA family could be created. h
   - Don't forget to install clr package to your Python 2.7 environment
 - You can package .csv databases into your component, with Daren's awesome [planets-example](/examples/planets/). But make sure it follows the same structure as his .csv example file, i.e. 1 header, comma separated, utf-8 encoding
   - Make sure you have `from __future__ import print_function` in your `.py` file, otherwise you'll get an error in Grasshopper: `The supplied data could not be converted: Parameter type: GH_Number. Supplied type: String`
-- Here is the results of checking compabitility of IronPython and Rhino. Best option is to use IronPython 2.6.8 with Rhino 6 SDK, as it will work for both RHino 6 and 7 no problemos. Rhino SDKs are forward but not backward compatible.
+- Here are the results of checking compabitility of IronPython and Rhino. Best option is to use IronPython 2.6.8 with Rhino 6 SDK, as it will work for both Rhino 6 and 7 no problemos. Rhino SDKs are forward but not backward compatible.
 
 |IronPython version | Rhino SDK version | Worked in Rhino 6 | Worked in Rhino 7|
 |-|-|-|-|

--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ parameters, a GH component for each script in the CEA family could be created. h
 ## How To Use
 
 - open command shell (windows-key + R, then enter ``cmd``)
-- navigate to your IronPython installation folder, for me it's C:\Program Files\IronPython 2.7
+- navigate to your IronPython installation folder, for me it's C:\Program Files\IronPython 2.7 (although Rhino ships with IronPython, you need a **standalone version installed**)
 - enter: ``ipy.exe honey-badger_path\honey-badger.py -i grasshopper-project_path\component.json``
-  - NOTE: You should have the exact same version of IronPython installed as Grasshopper uses. At the time of writing this is 2.7.8 and can be installed from here: https://github.com/IronLanguages/ironpython2/releases/tag/ipy-2.7.8
+  - NOTE: You should have the exact same version of IronPython installed as Grasshopper uses. At the time of writing this is [2.7.8](https://github.com/IronLanguages/ironpython2/releases/tag/ipy-2.7.8) for Rhino 6, [2.7.9](https://github.com/IronLanguages/ironpython2/releases/tag/ipy-2.7.9) for RHino 7.
+  - use `-v [6 or 7]` to specify Rhino version to use for SDK. Default is 6.
+  - use `-s` to skip a compability check between rhino version and IronPython version used. Default False (as in, checks compatibility by default).
+  - You can always check the IronPython version used in Rhino by navigating to `C:\Program Files\Rhino 7\Plug-ins\IronPython\IronPython.dll`, rightclick Properties > Details Tab > File Version Property.
 - your new python component should now be loaded when opening grasshopper
 
 ## A collection of links and facts I've found while researching possible solutions
@@ -47,3 +50,13 @@ parameters, a GH component for each script in the CEA family could be created. h
   - Don't forget to install clr package to your Python 2.7 environment
 - You can package .csv databases into your component, with Daren's awesome [planets-example](/examples/planets/). But make sure it follows the same structure as his .csv example file, i.e. 1 header, comma separated, utf-8 encoding
   - Make sure you have `from __future__ import print_function` in your `.py` file, otherwise you'll get an error in Grasshopper: `The supplied data could not be converted: Parameter type: GH_Number. Supplied type: String`
+- Here is the results of checking compabitility of IronPython and Rhino. Best option is to use IronPython 2.6.8 with Rhino 6 SDK, as it will work for both RHino 6 and 7 no problemos. Rhino SDKs are forward but not backward compatible.
+
+|IronPython version | Rhino SDK version | Worked in Rhino 6 | Worked in Rhino 7|
+|-|-|-|-|
+|2.7.8| 6| yes| yes|
+|2.7.8| 7| warning about SDK but seemed to work| yes|
+|2.7.9| 6| no| yes|
+|2.7.9| 7| no| yes|
+|2.7.11| 6| no| no|
+|2.7.11| 7| no| no|

--- a/honey-badger.py
+++ b/honey-badger.py
@@ -226,7 +226,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="honey-badger - make for .ghpy")
     parser.add_argument('-e', '--editable', action="store_true", default=False)
     parser.add_argument('-i', '--install', action="store_true", default=False)
-    parser.add_argument('-v', '--rhino-version', choices=['6','7'], default='7', help='Specifies which Rhino version to badger to (only 6 or 7 supported)')
+    parser.add_argument('-v', '--rhino-version', choices=['6','7'], default='6', help='Specifies which Rhino SDK version to badger to (only 6 or 7 supported)')
     parser.add_argument('-s', '--skip-compatibility-check', action='store_true', default=False, help='Skips checking IronPython and Rhino compatibility.')
     parser.add_argument('file', action="store")
     args = parser.parse_args(sys.argv[1:])

--- a/honey-badger.py
+++ b/honey-badger.py
@@ -35,10 +35,13 @@ clr.AddReference("System.IO")
 import System
 import System.IO
 
+import parameter_compiler
 
 def main(badger_file, editable, install, rhino_version, skip_compatibility_check):
     
     if not skip_compatibility_check:
+        # Asserts rhino version is installed and compatible with IronPython used.
+        
         rhino_to_ipy_version = {
             '6': ['2.7.8'],
             '7': ['2.7.8', '2.7.9']
@@ -55,11 +58,19 @@ def main(badger_file, editable, install, rhino_version, skip_compatibility_check
                 version_actual=ipy_version_actual
                 )
         
-        assert os.path.exists("C:\\Program Files\\Rhino {v}\\Plug-ins\\Grasshopper\\Grasshopper.dll".format(v=rhino_version)), "Could not find Grasshopper.dll. Is Rhino {v} installed?".format(v=rhino_version)
-        assert os.path.exists("C:\\Program Files\\Rhino {v}\System\\RhinoCommon.dll".format(v=rhino_version)), "Could not find RhinoCommon.dll. Is Rhino {v} installed?".format(v=rhino_version)
+        assert os.path.exists(
+            os.path.join(os.path.expandvars("${PROGRAMFILES}"),
+                         "Rhino {v}".format(v=rhino_version),
+                         "Plug-ins", "Grasshopper", "Grasshopper.dll")), \
+            "Could not find Grasshopper.dll. Is Rhino {v} installed?".format(v=rhino_version)
+        
+        assert os.path.exists(
+            os.path.join(os.path.expandvars("${PROGRAMFILES}"),
+                         "Rhino {v}".format(v=rhino_version),
+                         "System", "RhinoCommon.dll")), \
+            "Could not find RhinoCommon.dll. Is Rhino {v} installed?".format(v=rhino_version)
     
-    os.environ['RHINO_VERSION'] = rhino_version
-    import parameter_compiler
+    parameter_compiler.setup(rhino_version)
     
     try:
         # temporary create the helloworld dll adding the honey-badger.json to it

--- a/honey-badger.py
+++ b/honey-badger.py
@@ -49,7 +49,7 @@ def main(badger_file, editable, install, rhino_version, skip_compatibility_check
         # Checks that IronPython is being used
         assert platform.python_implementation() == 'IronPython', "You need to use IronPython to badger your components. Currently using {}".format(platform.python_implementation())
         assert ipy_version_actual in ipy_version_allowed, \
-            "IronPython version does not match for Rhino {rhino_version}. Must be {version} but was {wrong_version}".format(
+            "IronPython version does not match for Rhino {rhino_version}. Must be {version_target} but was {version_actual}".format(
                 rhino_version=rhino_version,
                 version_target=' or '.join(ipy_version_allowed),
                 version_actual=ipy_version_actual

--- a/parameter_compiler.py
+++ b/parameter_compiler.py
@@ -10,16 +10,17 @@ import csv
 import json
 import clr
 
+RHINO_VERSION = os.environ['RHINO_VERSION']
+
 clr.AddReference("IronPython")
 clr.AddReference("System")
 clr.AddReference("System.Reflection")
 
-
 hbrt_path = os.path.join(os.path.dirname(os.path.normpath(os.path.abspath(__file__))), "honey-badger-runtime", "bin",
                          "honey-badger-runtime.dll")
 clr.AddReferenceToFileAndPath(hbrt_path)
-clr.AddReferenceToFileAndPath(r"C:\Program Files\Rhino 6\Plug-ins\Grasshopper\Grasshopper.dll")
-clr.AddReferenceToFileAndPath(r"C:\Program Files\Rhino 6\System\RhinoCommon.dll")
+clr.AddReferenceToFileAndPath("C:\\Program Files\\Rhino {v}\\Plug-ins\\Grasshopper\\Grasshopper.dll".format(v=RHINO_VERSION))
+clr.AddReferenceToFileAndPath("C:\\Program Files\\Rhino {v}\System\\RhinoCommon.dll".format(v=RHINO_VERSION))
 
 from System import Array, Type, AppDomain
 from System.Reflection import (AssemblyName, TypeAttributes, MethodInfo, MethodAttributes, CallingConventions,

--- a/parameter_compiler.py
+++ b/parameter_compiler.py
@@ -10,26 +10,39 @@ import csv
 import json
 import clr
 
-RHINO_VERSION = os.environ['RHINO_VERSION']
-
 clr.AddReference("IronPython")
 clr.AddReference("System")
 clr.AddReference("System.Reflection")
-
-hbrt_path = os.path.join(os.path.dirname(os.path.normpath(os.path.abspath(__file__))), "honey-badger-runtime", "bin",
-                         "honey-badger-runtime.dll")
-clr.AddReferenceToFileAndPath(hbrt_path)
-clr.AddReferenceToFileAndPath("C:\\Program Files\\Rhino {v}\\Plug-ins\\Grasshopper\\Grasshopper.dll".format(v=RHINO_VERSION))
-clr.AddReferenceToFileAndPath("C:\\Program Files\\Rhino {v}\System\\RhinoCommon.dll".format(v=RHINO_VERSION))
 
 from System import Array, Type, AppDomain
 from System.Reflection import (AssemblyName, TypeAttributes, MethodInfo, MethodAttributes, CallingConventions,
                                PropertyAttributes)
 from System.Reflection.Emit import AssemblyBuilderAccess, OpCode, OpCodes
-from Grasshopper.Kernel import GH_AssemblyInfo
 
-from HoneyBadgerRuntime import HoneyBadgerValueList, HoneyBadgerRuntimeInfo
 import System.IO
+
+
+def setup(rhino_version):
+    """
+    Loads the RhinoCommon and Grasshopper libraries based on the desired/installed Rhino version.
+    Also loads the HoneyBadgerRuntime dll since it was somehow not working when imported above (maybe needs the Rhino dlls loaded first?)..
+    """
+    global GH_AssemblyInfo
+    clr.AddReferenceToFileAndPath(os.path.join(os.path.expandvars("${PROGRAMFILES}"),
+                         "Rhino {v}".format(v=rhino_version),
+                         "Plug-ins", "Grasshopper", "Grasshopper.dll"))
+    clr.AddReferenceToFileAndPath(os.path.join(os.path.expandvars("${PROGRAMFILES}"),
+                            "Rhino {v}".format(v=rhino_version),
+                            "System", "RhinoCommon.dll"))
+    from Grasshopper.Kernel import GH_AssemblyInfo
+    
+    global HoneyBadgerRuntimeInfo, HoneyBadgerValueList
+    
+    hbrt_path = os.path.join(os.path.dirname(os.path.normpath(os.path.abspath(__file__))), "honey-badger-runtime", "bin",
+                            "honey-badger-runtime.dll")
+    clr.AddReferenceToFileAndPath(hbrt_path)
+    from HoneyBadgerRuntime import HoneyBadgerValueList, HoneyBadgerRuntimeInfo
+
 
 
 def compile_parameters(badger_config, badger_dir, dll_path):


### PR DESCRIPTION
- Creates optional parameter to define rhino version for importing correct DLLs, Default is Rhino 6.
- Compatibility check to make sure Rhino version installed and matches IronPython being used to badger (must match exactly, as stated in readme)
- Optional param to skip compatability check (really just need it once for setup of dev env)

Closes #16 
Closes #17 
Closes architecture-building-systems/hive#513

Findings:
- Rhino plugins are forward compatible but not backwards compatible. This means plugins built with Rhino 6 SDK and IronPython 2.7.8 (for Rhino 6) will work in Rhino 7. However, building with Rhino 7 SDK might cause issues in Rhino 6, and building with another version of IronPython will also not make the badger happy. See https://discourse.mcneel.com/t/versioning-scheme-used-by-rhino-sdk/74377.


|IronPython version | Rhino SDK version | Worked in Rhino 6 | Worked in Rhino 7|
|-|-|-|-|
|2.7.8| 6| yes| yes|
|2.7.8| 7| warning about SDK but seemed to work| yes|
|2.7.9| 6| no| yes|
|2.7.9| 7| no| yes|
|2.7.11| 6| no| no|
|2.7.11| 7| no| no|

So safest bet for both compatibility is IronPython 2.7.8 with Rhino 6 SDK (but relies on Rhino 6 being installed)
